### PR TITLE
fix expired license + super server port = 1972

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 #
 # SAML-COS sample environment
 #
-ARG IMAGE=intersystemsdc/irishealth-community
+
+#ARG IMAGE=store/intersystems/irishealth-community:2020.1.0.215.0
+#ARG IMAGE=store/intersystems/irishealth-community:2020.4.0.547.0
+ARG IMAGE=store/intersystems/irishealth-community:2021.1.0.215.3
+ARG IMAGE=intersystemsdc/irishealth-community:2021.1.0.215.3-zpm
 FROM $IMAGE
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
 #
 # SAML-COS sample environment
 #
-
-#ARG IMAGE=store/intersystems/irishealth-community:2020.1.0.215.0
-#ARG IMAGE=store/intersystems/irishealth-community:2020.4.0.547.0
-ARG IMAGE=store/intersystems/irishealth-community:2021.1.0.215.0
-ARG IMAGE=intersystemsdc/irishealth-community:2021.1.0.215.0-zpm
+ARG IMAGE=intersystemsdc/irishealth-community
 FROM $IMAGE
 
 USER root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     image: saml-cos:dev
     container_name: saml-cos
     ports:
-    - "51773:51773"
+    - "51773:1972"
     - "52773:52773"
     volumes:
     - .:/app


### PR DESCRIPTION
Error: Invalid Community Edition license, may have exceeded core limit. - Shutting down the
 system : $zu(56,2)= 0Starting IRIS

An error was detected during InterSystems IRIS startup.
** Startup aborted **
ERROR: Service 'saml-cos' failed to build : The command '/bin/sh -c iris start IRIS     &&
iris session IRIS < iris.script     && iris stop IRIS quietly' returned a non-zero code: 1