### PR TITLE
make version independent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@
 ARG IMAGE=store/intersystems/irishealth-community:2021.1.0.215.3
 ARG IMAGE=intersystemsdc/irishealth-community:2021.1.0.215.3-zpm
 ARG IMAGE=intersystemsdc/irishealth-community:2022.1.1.374.0-zpm
+ARG IMAGE=intersystemsdc/irishealth-community
 FROM $IMAGE
 
 USER root


### PR DESCRIPTION
Error: Invalid Community Edition license, may have exceeded core limit.