### PR TITLE
To be able to not use a SAMLValidator

### DIFF
--- a/src/IBSP/CONN/SAML/BO/SAMLSigner.cls
+++ b/src/IBSP/CONN/SAML/BO/SAMLSigner.cls
@@ -78,7 +78,11 @@ Method SignedAssertion(pRequest As IBSP.CONN.SAML.Msg.SAMLReq, Output pResponse 
 		set pResponse=##class(Ens.StringResponse).%New()
 		//--- Validate that all Attributes are present
 		set tAttributes={}.%FromJSON(pRequest.data.SAMLAttributes)
-		$$$THROWONERROR(tSC,..ValidateAttributes(pRequest.data.SAMLValidator,tAttributes))
+
+		if (pRequest.data.SAMLValidator'=$$$NULLOREF) {
+			$$$THROWONERROR(tSC,..ValidateAttributes(pRequest.data.SAMLValidator,tAttributes))
+		}
+		
 		//---
 		//--- Override Missing values with Default Settings
 		set tX509Alias=$select(pRequest.data.X509CertAlias="":..X509CertAlias,1:pRequest.data.X509CertAlias)


### PR DESCRIPTION
As not always, we want to use a SAMLValidator I have forked the original component to be able to avoid it. If you just have got a SAMLValidator, it will validate attributes but if you leave it empty, no validations will be done. It will make easier to build new integrations because in other case, you have to modify standard code to accept your new validator.

Just a line has been changed (added IF sentence):
```
		if (pRequest.data.SAMLValidator'=$$$NULLOREF) {
			$$$THROWONERROR(tSC,..ValidateAttributes(pRequest.data.SAMLValidator,tAttributes))
		}
```