### PR TITLE
New setting to add Audience Restriction to the SAML ticket

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Interaction scheme between the different production components for the generatio
 | SAMLIssuer | HospitalXYZ | SAMLissuer name as specified by CatSalut. An arbitrary name works |
 | SAMLTimeToLive | 600 | SAML token validity time in seconds. After this time (in case of message resending), the token will be rejected |
 | SAMLAttributes | {"ResponsibleUser":"HCC0123AB","Profile":"MD","ProviderOrganization":"H0800000","Entity":"0123","CodeUp":"01234","GivenName":"SUPPORT","FirstFamilyName":"SUPPORT","DocumentType":"01","DocumentNumber":"12345678Z","Code":"108323233"} | SAML Attributes List. These attributes vary depending on the CatSalut Service to be invoked. The attributes are specified in JSON format from the portal. |
+| SAMLAudienceRestrictionURL | https://samlticket.example.com/SAML2 | Audience to whom the SAML Ticket is intended for. Urls can be separated by ; |
 
 SAML configuration parameters can be defined in several places: some attribute values can be specific to each call (e.g. the identification of a physician signing a clinical document), others specific to a Web service, and others common to all calls (same X509 Certificate for all calls). To give more flexibility, SAML parameters and attributes can be defined in 3 places
 

--- a/src/IBSP/CONN/SAML/BO/SAMLHelper.cls
+++ b/src/IBSP/CONN/SAML/BO/SAMLHelper.cls
@@ -17,7 +17,10 @@ Property SAMLTimeToLive As %Integer [ InitialExpression = 600 ];
 /// { "ResponsibleUser":"HCC0555WS", "Profile": "MD" }
 Property SAMLAttributes As %String(MAXLEN = "");
 
-Parameter SETTINGS = "X509CertAlias:SAML,SAMLIssuer:SAML,SAMLTimeToLive:SAML,SAMLAttributes:SAML,ReplyCodeActions,RetryInterval,AlertRetryGracePeriod:Alerting,FailureTimeout,QueueCountAlert:Alerting,QueueWaitAlert:Alerting,SendSuperSession";
+/// URLs para incluir como Condition (en AudienceRestriction). Se permite más de una URL separadas por puntos y coma ;
+Property SAMLAudienceRestrictionURL As %String(MAXLEN = "");
+
+Parameter SETTINGS = "SAMLAudienceRestrictionURL:SAML,X509CertAlias:SAML,SAMLIssuer:SAML,SAMLTimeToLive:SAML,SAMLAttributes:SAML,ReplyCodeActions,RetryInterval,AlertRetryGracePeriod:Alerting,FailureTimeout,QueueCountAlert:Alerting,QueueWaitAlert:Alerting,SendSuperSession";
 
 /// API a invocar para genear un token SAML dentro de una Cabecera SOAP, para poder enviarlo como
 /// SOAP Security Header como parte de una llamada a un Web Service.
@@ -34,7 +37,8 @@ Method GetSAMLToken(pValidator As %String, pSAMLParams As IBSP.CONN.SAML.Data.SA
 	set tX509CertAlias=$select(pSAMLParams.X509CertAlias="":..X509CertAlias,1:pSAMLParams.X509CertAlias)
 	set tSAMLIssuer=$select(pSAMLParams.SAMLIssuer="":..SAMLIssuer,1:pSAMLParams.SAMLIssuer)
 	set tSAMLTimeToLive=$select(pSAMLParams.SAMLTimeToLive="":..SAMLTimeToLive,1:pSAMLParams.SAMLTimeToLive)
-	
+	set tSAMLAudienceRestriction=$select(pSAMLParams.SAMLAudienceRestrictionURL="":..SAMLAudienceRestrictionURL,1:pSAMLParams.SAMLAudienceRestrictionURL)
+
 	//--Get Default SAML Attribute values from Portal if any
 	$$$TRACE(..SAMLAttributes)
 	set tDefaultAttObj=$Select(..SAMLAttributes="":{},1:{}.%FromJSON(..SAMLAttributes))
@@ -55,6 +59,7 @@ Method GetSAMLToken(pValidator As %String, pSAMLParams As IBSP.CONN.SAML.Data.SA
 	set request.data.SAMLIssuer=tSAMLIssuer
 	set request.data.SAMLTimeToLive=tSAMLTimeToLive
 	set request.data.SAMLValidator=pValidator
+	set request.data.SAMLAudienceRestrictionURL=tSAMLAudienceRestriction
 	
 	set header=##class(IBSP.CONN.SAML.SOAPHeader).%New()
 	try {

--- a/src/IBSP/CONN/SAML/BO/SAMLSigner.cls
+++ b/src/IBSP/CONN/SAML/BO/SAMLSigner.cls
@@ -109,6 +109,20 @@ Method SignedAssertion(pRequest As IBSP.CONN.SAML.Msg.SAMLReq, Output pResponse 
 	quit tSC
 }
 
+/// Create an %SAML.AudienceRestriction object with the URL received in the parameter
+Method CreateAudienceRestriction(audienceRestrictionURL as %String="") As %SAML.AudienceRestriction
+{
+	try {
+		Set tSC=$$$OK
+		Set tAudienceRestriction=##class(%SAML.AudienceRestriction).%New()
+		Do tAudienceRestriction.Audience.Insert(audienceRestrictionURL)
+	} catch ex {
+		Set tSC=ex.AsStatus()
+		Set tAudienceRestriction=""
+	}
+	Quit tAudienceRestriction
+}
+
 /// Fills the Assertion with the Values, Conditions and Attributes.
 Method FillAssertion(ByRef tAssertion As %SAML.Assertion, pRequest As IBSP.CONN.SAML.Msg.SAMLReq, pSAMLIssuer As %String, pSAMLTimeToLive As %Integer, pCredentials As %SYS.X509Credentials) As %Status
 {
@@ -143,6 +157,17 @@ Method FillAssertion(ByRef tAssertion As %SAML.Assertion, pRequest As IBSP.CONN.
 		set conditions = ##class(%SAML.Conditions).%New()
 		set conditions.NotBefore=now1
 		set conditions.NotOnOrAfter=now2
+		
+		if (pRequest.data.SAMLAudienceRestrictionURL'=$$$NULLOREF) {
+			For i=1:1:$LENGTH(pRequest.data.SAMLAudienceRestrictionURL,";") {
+    				Set audienceURL = $PIECE(pRequest.data.SAMLAudienceRestrictionURL,";",i)
+    				if (audienceURL'=$$$NULLOREF) {
+					set audienceRestriction = ..CreateAudienceRestriction(audienceURL)
+					do conditions.Condition.Insert(audienceRestriction)
+    				}
+			}
+		}
+
 		set tAssertion.Conditions=conditions
 	
 		do tAssertion.Statement.Clear()

--- a/src/IBSP/CONN/SAML/Data/SAMLValues.cls
+++ b/src/IBSP/CONN/SAML/Data/SAMLValues.cls
@@ -26,6 +26,9 @@ Property SAMLValidator As %String(VALUELIST = ",Generic,ConsultaETC,ServeisSocia
 /// { "ResponsibleUser":"HCC0555WS", "Profile": "MD" }
 Property SAMLAttributes As %String(MAXLEN = "");
 
+/// URLs para incluir como Condition (en AudienceRestriction)
+Property SAMLAudienceRestrictionURL As %String(MAXLEN="");
+
 /// El Tipo de Token SAML Pedido, al cual corresponden una serie de atributos obligatorios
 Storage Default
 {


### PR DESCRIPTION
With the change, user can configure a new setting with a list of URLs to include in the Audience Restriction tag inside the Conditions in the SAML ticket.